### PR TITLE
Refactor constant representation

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -55,7 +55,7 @@ interpret(ctx::Context, graph::IVertex, args...) =
 
 # The `ifoo` convention denotes a piece of interpreter middleware
 
-iconst(f, ctx::Context, x::Constant) = x.value
+iconst(f, ctx::Context, ::Constant, x) = value(x)
 
 function iline(f, ctx::Context, l::Union{Line,Frame}, v)
   push!(ctx.stack, l)

--- a/src/syntax/dump.jl
+++ b/src/syntax/dump.jl
@@ -11,7 +11,7 @@ function syntax(head::DVertex; bindconst = !isfinal(head))
   for v in vs
     x = tocall(value(v), [binding(bs, n) for n in inputs(v)]...)
     if !bindconst && isconstant(v) && nout(v) > 1
-      bs[v] = value(v).value
+      bs[v] = v[1].value
     elseif nout(v) > 1 || (!isfinal(head) && v ≡ head)
       edge = binding(bs, v)
       push!(ex.args, :($edge = $x))
@@ -29,16 +29,13 @@ function syntax(head::DVertex; bindconst = !isfinal(head))
   return ex
 end
 
+# TODO: this is butt ugly
+
 function constructor(g)
   vertex = isa(g, DVertex) ? :dvertex : :vertex
   g = mapv(g) do v
-    if isconstant(v)
-      prethread!(v, typeof(v)(value(v)))
-      v.value = :constant
-    else
-      prethread!(v, typeof(v)(Constant(value(v))))
-      v.value = vertex
-    end
+    prethread!(v, typeof(v)(Constant(), typeof(v)(value(v))))
+    v.value = vertex
     v
   end
   ex = syntax(g)

--- a/src/syntax/read.jl
+++ b/src/syntax/read.jl
@@ -50,8 +50,8 @@ function fillnodes!(bindings, nodes)
   # TODO: remove this once constants are fixed
   for b in nodes
     node = bindings[b]
-    if isa(node, Vertex) && isconstant(node) && haskey(bindings, value(node).value)
-      alias = bindings[value(node).value]
+    if isa(node, Vertex) && isconstant(node) && haskey(bindings, value(node[1]))
+      alias = bindings[value(node[1])]
       isa(alias, LateVertex) && (alias = alias.val)
       bindings[b] = alias
     end

--- a/src/syntax/sugar.jl
+++ b/src/syntax/sugar.jl
@@ -32,24 +32,16 @@ tocall(::typeof(broadcast), f, xs...) = :($f.($(xs...)))
 
 # Constants
 
-struct Constant{T}
-  value::T
-end
+struct Constant end
 
-tocall(c::Constant) = c.value
+tocall(c::Constant, x) = x.args[1]
 
 isconstant(v::Vertex) = isa(value(v), Constant)
 
-mapconst(f, g) = map(x -> isa(x, Constant) ? Constant(f(x.value)) : f(x), g)
+constant(x) = vertex(Constant(), vertex(x))
+constant(v::Vertex) = vertex(v)
 
-a::Constant == b::Constant = a.value == b.value
-
-Base.hash(c::Constant, h::UInt = UInt(0)) = hash((Constant, c.value), h)
-
-for (c, v) in [(:constant, :vertex), (:dconstant, :dvertex)]
-  @eval $c(x) = $v(Constant(x))
-  @eval $c(v::Vertex) = $v(v)
-end
+# Blocks
 
 struct Do end
 
@@ -216,4 +208,4 @@ function normclosures(ex)
 end
 
 # TODO: nested closures
-flopen(v::IVertex) = mapconst(x->x==LooseEnd()?Input():x,v)
+flopen(v::IVertex) = map(x->x==LooseEnd()?Input():x,v)

--- a/src/syntax/sugar.jl
+++ b/src/syntax/sugar.jl
@@ -157,7 +157,7 @@ splitnode(v, n) = vertex(Split(n), v)
 
 inputnode(n) = splitnode(constant(Input()), n)
 
-isinput(v::IVertex) = isa(value(v), Split) && value(v[1]) == Constant(Input())
+isinput(v::IVertex) = isa(value(v), Split) && isconstant(v[1]) && value(v[1][1]) == Input()
 
 function bumpinputs(v::IVertex)
   prewalk(v) do v
@@ -169,7 +169,7 @@ end
 
 function spliceinput(v::IVertex, input::IVertex)
   postwalk(v) do v
-    value(v) == Constant(Input()) ? input : v
+    isconstant(v) && value(v[1]) == Input() ? input : v
   end
 end
 

--- a/src/syntax/syntax.jl
+++ b/src/syntax/syntax.jl
@@ -57,7 +57,7 @@ end
 function flowm(ex, f = dl)
   isdef(ex) && return flow_func(ex)
   g = graphm(block(ex))
-  g = mapconst(x -> isexpr(x, :$) ? esc(x.args[1]) : Expr(:quote, x), g)
+  g = map(x -> isexpr(x, :$) ? esc(x.args[1]) : Expr(:quote, x), g)
   constructor(f(g))
 end
 
@@ -71,7 +71,7 @@ end
 
 function vtxm(ex, f = dl)
   exs = graphm(block(ex))
-  @>> exs graphm mapconst(esc) f constructor
+  @>> exs graphm map(esc) f constructor
 end
 
 macro vtx(ex)


### PR DESCRIPTION
This changes the representation of constants. Things like `mapconst` were a design smell. Constants are now represented as `(constant (x))` which is more verbose but actually more consistent, and therefore easier to work with.

It would probably be best to make calls consistent by marking them explicitly as well. This would mean that `f(x, y)` is represented by `(call (constant (f)) (constant (x)) (constant (y)))`, which is kinda weird. But we'll need something like `call` to support first-class functions anyway.

This is obviously breaking.